### PR TITLE
WordPress 6.3 Compatibility For Astra Customizer Reset 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Astra Customizer Reset #
 **Contributors:** [brainstormforce](https://profiles.wordpress.org/brainstormforce)  
 **Tags:** astra theme, customizer reset, reset astra customizer, reset astra theme  
-**Tested up to:** 6.2  
+**Tested up to:** 6.3  
 **Stable tag:** 1.0.6  
 **Requires at least:** 4.4  
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Astra Customizer Reset ===
 Contributors: brainstormforce
 Tags: astra theme, customizer reset, reset astra customizer, reset astra theme
-Tested up to: 6.2
+Tested up to: 6.3
 Stable tag: 1.0.6
 Requires at least: 4.4
 


### PR DESCRIPTION
Summary
- Provided WordPress 6.3 Compatibility.

Changes Made
- Updated Readme "Tested Upto" version to 6.3

Testing
- Tested with Astra, Astra Addon
- Checked by setting few Astra options and resetting to see if they reset properly in customizer and frontend.
- Checked by setting few Astra Addon options as well.