### PR TITLE
fix: reset custom_logo theme mod on customizer reset

### DIFF
--- a/class-astra-theme-customizer-reset.php
+++ b/class-astra-theme-customizer-reset.php
@@ -119,6 +119,9 @@ if ( ! class_exists( 'Astra_Theme_Customizer_Reset' ) ) :
 
 				// Delete Astra's 4.0.0 admin setting options.
 				delete_option( 'astra_admin_settings' );
+
+				// Reset the site logo (stored as a theme mod, not in Astra settings).
+				remove_theme_mod( 'custom_logo' );
 			}
 
 			wp_send_json_error( 'pass' );

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,11 @@
         "wp-coding-standards/wpcs": "dev-master",
         "phpcompatibility/phpcompatibility-wp": "*"
     },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    },
     "scripts": {
         "format": "phpcbf --standard=phpcs.xml.dist --report-summary --report-source",
         "lint": "phpcs --standard=phpcs.xml.dist --report-summary --report-source"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb82ddd5e1a7ffa53eb9a31513b41bd2",
+    "content-hash": "e45e3ee2580ddbe23ea420baba3d470c",
     "packages": [],
     "packages-dev": [
         {

--- a/readme.txt
+++ b/readme.txt
@@ -43,6 +43,9 @@ No! Once you reset the customizer settings you can not revert it back. You will 
 
 == Changelog ==
 
+= 1.0.7 =
+- Fix: Site logo (custom_logo) not being reset when using the customizer reset button.
+
 = 1.0.6 =
 - Improvement: Compatibility with Astra 4.0.0.
 


### PR DESCRIPTION
## Summary

- The site logo (`custom_logo`) is stored as a WordPress theme mod, not inside the `astra-settings` option. This meant it was never cleared when the reset button was clicked.
- Added `remove_theme_mod( 'custom_logo' )` inside the existing reset block to fix this.

Replaces #47 (clean cherry-pick without whitespace/formatting changes).

## Test plan

- [x] Set a logo via Appearance > Customize > Site Identity
- [x] Click the Reset All button
- [x] Confirm the logo is removed after the customizer reloads